### PR TITLE
Audit all fields on update, no matter they are changed or not

### DIFF
--- a/src/Auditable.php
+++ b/src/Auditable.php
@@ -130,7 +130,15 @@ trait Auditable
      */
     protected function auditUpdatedAttributes(array &$old, array &$new)
     {
+        /*
         foreach ($this->getDirty() as $attribute => $value) {
+            if ($this->isAttributeAuditable($attribute)) {
+                $old[$attribute] = array_get($this->original, $attribute);
+                $new[$attribute] = array_get($this->attributes, $attribute);
+            }
+        }
+        */
+        foreach ($this->attributes as $attribute => $value) {
             if ($this->isAttributeAuditable($attribute)) {
                 $old[$attribute] = array_get($this->original, $attribute);
                 $new[$attribute] = array_get($this->attributes, $attribute);


### PR DESCRIPTION
Audits every field marked as auditable, doesn't use Eloquent Model's getDirty()